### PR TITLE
Update partner page and add partner profiles

### DIFF
--- a/flexlift.html
+++ b/flexlift.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tirugo GmbH – Partner</title>
-    <meta name="description" content="Unsere Partnerfirmen im Überblick.">
-    <link rel="canonical" href="/partner.html">
+    <title>Partner – FlexLift</title>
+    <meta name="description" content="Informationen zum Partner FlexLift.">
+    <link rel="canonical" href="/flexlift.html">
+    <link rel="preload" as="image" href="assets/header.webp">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/responsive.css">
@@ -17,7 +18,7 @@
 <header>
     <nav aria-label="Hauptnavigation">
         <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
+        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
         <ul id="nav-list" class="nav-list">
             <li><a href="produkte.html">Produkte</a></li>
             <li><a href="partner.html">Partner</a></li>
@@ -33,35 +34,14 @@
     </nav>
 </header>
 
-<!-- PARTNER -->
-<section class="banner" style="background-image:url('assets/empack_1.webp')">
-    <h1>Partner</h1>
-</section>
-<section class="blog-section">
-    <h2>Unsere Partner</h2>
-    <div class="blog-list">
-        <article>
-            <img src="assets/Petec_Logo.webp" alt="PETEC Logo" loading="lazy">
-            <h3>PETEC</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="petec.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Flexlift_Logo.webp" alt="FlexLift Logo" loading="lazy">
-            <h3>FlexLift</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="flexlift.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Transort_Logo.webp" alt="Transort Logo" loading="lazy">
-            <h3>Transort</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="transort.html">Mehr erfahren</a>
-        </article>
-    </div>
-</section>
-<p>Werden Sie Partner – Kontaktieren Sie uns unter info@firma.ch</p>
 
+<section class="banner" style="background-image:url('assets/empack_1.webp')">
+    <h1>FlexLift</h1>
+</section>
+<section class="about">
+    <img src="assets/Flexlift_Logo.webp" alt="FlexLift Logo" loading="lazy">
+    <p>Kurzbeschreibung zu FlexLift.</p>
+</section>
 <!-- FOOTER -->
 <footer>
     <ul class="quicklinks">

--- a/js/search.js
+++ b/js/search.js
@@ -11,7 +11,10 @@ document.addEventListener('DOMContentLoaded', () => {
     { title: 'Datenschutz',      url: 'datenschutz.html',     keywords: 'privacy policy' },
     { title: 'Online Beratung',  url: 'online-beratung.html',  keywords: 'online beratung' },
     { title: 'FAQ',              url: 'faq.html',              keywords: 'häufig gestellte fragen' },
-    { title: 'Login',            url: 'login.html',            keywords: 'login portal' }
+    { title: 'Login',            url: 'login.html',            keywords: 'login portal' },
+    { title: 'PETEC',            url: 'petec.html',           keywords: 'partner petec' },
+    { title: 'FlexLift',         url: 'flexlift.html',        keywords: 'partner flexlift' },
+    { title: 'Transort',         url: 'transort.html',        keywords: 'partner transort' }
   ];
 
   let selectedIndex = -1;

--- a/petec.html
+++ b/petec.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tirugo GmbH – Partner</title>
-    <meta name="description" content="Unsere Partnerfirmen im Überblick.">
-    <link rel="canonical" href="/partner.html">
+    <title>Partner – PETEC</title>
+    <meta name="description" content="Informationen zum Partner PETEC.">
+    <link rel="canonical" href="/petec.html">
+    <link rel="preload" as="image" href="assets/header.webp">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/responsive.css">
@@ -17,7 +18,7 @@
 <header>
     <nav aria-label="Hauptnavigation">
         <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
+        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
         <ul id="nav-list" class="nav-list">
             <li><a href="produkte.html">Produkte</a></li>
             <li><a href="partner.html">Partner</a></li>
@@ -33,35 +34,14 @@
     </nav>
 </header>
 
-<!-- PARTNER -->
-<section class="banner" style="background-image:url('assets/empack_1.webp')">
-    <h1>Partner</h1>
-</section>
-<section class="blog-section">
-    <h2>Unsere Partner</h2>
-    <div class="blog-list">
-        <article>
-            <img src="assets/Petec_Logo.webp" alt="PETEC Logo" loading="lazy">
-            <h3>PETEC</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="petec.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Flexlift_Logo.webp" alt="FlexLift Logo" loading="lazy">
-            <h3>FlexLift</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="flexlift.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Transort_Logo.webp" alt="Transort Logo" loading="lazy">
-            <h3>Transort</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="transort.html">Mehr erfahren</a>
-        </article>
-    </div>
-</section>
-<p>Werden Sie Partner – Kontaktieren Sie uns unter info@firma.ch</p>
 
+<section class="banner" style="background-image:url('assets/empack_1.webp')">
+    <h1>PETEC</h1>
+</section>
+<section class="about">
+    <img src="assets/Petec_Logo.webp" alt="PETEC Logo" loading="lazy">
+    <p>Kurzbeschreibung zu PETEC.</p>
+</section>
 <!-- FOOTER -->
 <footer>
     <ul class="quicklinks">

--- a/transort.html
+++ b/transort.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tirugo GmbH – Partner</title>
-    <meta name="description" content="Unsere Partnerfirmen im Überblick.">
-    <link rel="canonical" href="/partner.html">
+    <title>Partner – Transort</title>
+    <meta name="description" content="Informationen zum Partner Transort.">
+    <link rel="canonical" href="/transort.html">
+    <link rel="preload" as="image" href="assets/header.webp">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/responsive.css">
@@ -17,7 +18,7 @@
 <header>
     <nav aria-label="Hauptnavigation">
         <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
+        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
         <ul id="nav-list" class="nav-list">
             <li><a href="produkte.html">Produkte</a></li>
             <li><a href="partner.html">Partner</a></li>
@@ -33,35 +34,14 @@
     </nav>
 </header>
 
-<!-- PARTNER -->
-<section class="banner" style="background-image:url('assets/empack_1.webp')">
-    <h1>Partner</h1>
-</section>
-<section class="blog-section">
-    <h2>Unsere Partner</h2>
-    <div class="blog-list">
-        <article>
-            <img src="assets/Petec_Logo.webp" alt="PETEC Logo" loading="lazy">
-            <h3>PETEC</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="petec.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Flexlift_Logo.webp" alt="FlexLift Logo" loading="lazy">
-            <h3>FlexLift</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="flexlift.html">Mehr erfahren</a>
-        </article>
-        <article>
-            <img src="assets/Transort_Logo.webp" alt="Transort Logo" loading="lazy">
-            <h3>Transort</h3>
-            <p>Kurzbeschreibung des Partners.</p>
-            <a href="transort.html">Mehr erfahren</a>
-        </article>
-    </div>
-</section>
-<p>Werden Sie Partner – Kontaktieren Sie uns unter info@firma.ch</p>
 
+<section class="banner" style="background-image:url('assets/empack_1.webp')">
+    <h1>Transort</h1>
+</section>
+<section class="about">
+    <img src="assets/Transort_Logo.webp" alt="Transort Logo" loading="lazy">
+    <p>Kurzbeschreibung zu Transort.</p>
+</section>
 <!-- FOOTER -->
 <footer>
     <ul class="quicklinks">


### PR DESCRIPTION
## Summary
- restyle `partner.html` with three entry boxes
- add new partner pages: `petec.html`, `flexlift.html`, `transort.html`
- include partner pages in search suggestions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68422bb157d48321ad8a83c13e4804bf