### PR TITLE
Add shared header/footer includes

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -13,25 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 <main class="container page-content">
     <h1>Datenschutz</h1>
     <section>
@@ -47,11 +29,6 @@
         <p>Ihnen stehen grundsätzlich die Rechte auf Auskunft, Berichtigung, Löschung, Einschränkung, Datenübertragbarkeit und Widerspruch zu. Wenn Sie glauben, dass die Verarbeitung Ihrer Daten gegen das Datenschutzrecht verstößt, können Sie sich bei uns oder der Aufsichtsbehörde beschweren.</p>
     </section>
 </main>
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -14,26 +14,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- FAQ -->
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -73,12 +54,7 @@
 </section>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 <script>
 document.querySelectorAll('.faq-question').forEach(q => {
     q.addEventListener('click', () => {

--- a/flexlift.html
+++ b/flexlift.html
@@ -14,26 +14,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -64,11 +45,6 @@
     <p><strong>TIRUGO GmbH – Technik mit Substanz. Flexlift Kompetenzpartner Schweiz.</strong></p>
 </section>
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -1,0 +1,6 @@
+<footer>
+    <ul class="quicklinks">
+        <li><a href="datenschutz.html">Datenschutz</a></li>
+    </ul>
+    <p>&copy; 2024 Tirugo GmbH</p>
+</footer>

--- a/includes/header.html
+++ b/includes/header.html
@@ -1,0 +1,28 @@
+<header role="banner" class="site-header">
+  <div class="container flex-between">
+    <!-- Logo -->
+    <a href="index.html" class="logo">
+      <img src="assets/logo-1.webp" alt="Firmenlogo" loading="lazy">
+    </a>
+    <!-- Navigation -->
+    <nav aria-label="Hauptnavigation">
+      <ul class="nav-list" id="nav-list">
+        <li><a href="produkte.html">Produkte</a></li>
+        <li><a href="partner.html">Partner</a></li>
+        <li><a href="ueber-uns.html">Über uns</a></li>
+        <li><a href="online-beratung.html">Online Beratung</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="login.html">Login</a></li>
+      </ul>
+    </nav>
+    <!-- Suchfeld -->
+    <div class="search-container" role="search">
+      <input type="text" id="site-search" placeholder="Seite durchsuchen…" aria-label="Seite durchsuchen" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false" autocomplete="off">
+      <ul id="search-suggestions" class="search-suggestions" role="listbox" aria-expanded="false"></ul>
+    </div>
+    <!-- Hamburger-Button (Mobile) -->
+    <button class="hamburger" aria-label="Menü öffnen" aria-expanded="false" aria-controls="nav-list">
+      <span class="hamburger-icon"></span>
+    </button>
+  </div>
+</header>

--- a/index.html
+++ b/index.html
@@ -14,26 +14,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 
 <section id="blog" class="blog-section">
@@ -72,11 +53,6 @@
     </div>
 </section>
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- LOGIN -->
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -54,12 +35,7 @@
 </section>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 <script>
 const loginForm = document.getElementById('login-form');
 loginForm.addEventListener('submit', e => {

--- a/online-beratung.html
+++ b/online-beratung.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- ONLINE BERATUNG -->
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -65,12 +46,7 @@
 </section>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 <script>
 // einfache Formularvalidierung
 const form = document.getElementById('beratung-form');

--- a/partner.html
+++ b/partner.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- PARTNER -->
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -64,11 +45,6 @@
 <p>Werden Sie Partner – Kontaktieren Sie uns unter info@firma.ch</p>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/petec.html
+++ b/petec.html
@@ -14,26 +14,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -44,11 +25,6 @@
     <p>Kurzbeschreibung zu PETEC.</p>
 </section>
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/produkte.html
+++ b/produkte.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- PRODUKTE -->
 <section class="banner products-banner">
@@ -97,11 +78,6 @@
 </section>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/service.html
+++ b/service.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- SERVICE -->
 <section class="banner" style="background-image:url('assets/header.webp')">
@@ -44,11 +25,6 @@
 </main>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/transort.html
+++ b/transort.html
@@ -14,26 +14,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" type="button" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -44,11 +25,6 @@
     <p>Kurzbeschreibung zu Transort.</p>
 </section>
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>

--- a/ueber-uns.html
+++ b/ueber-uns.html
@@ -13,26 +13,7 @@
     <script src="js/search.js" defer></script>
 </head>
 <body>
-<!-- HEADER -->
-<header>
-    <nav aria-label="Hauptnavigation">
-        <a href="index.html" class="logo"><img src="assets/logo-1.webp" alt="Tirugo Logo" loading="eager"></a>
-        <button class="hamburger" aria-controls="nav-list" aria-expanded="false">☰</button>
-        <ul id="nav-list" class="nav-list">
-            <li><a href="produkte.html">Produkte</a></li>
-            <li><a href="partner.html">Partner</a></li>
-            <li><a href="ueber-uns.html">Über uns</a></li>
-            <li><a href="online-beratung.html">Online Beratung</a></li>
-            <li><a href="faq.html">FAQ</a></li>
-            <li><a href="service.html">Service</a></li>
-            <li><a href="login.html">Login</a></li>
-        </ul>
-        <div class="search-container">
-            <input type="text" id="site-search" placeholder="Seite durchsuchen…" role="combobox" aria-autocomplete="list" aria-owns="search-suggestions" aria-expanded="false">
-            <ul id="search-suggestions" role="listbox" aria-expanded="false"></ul>
-        </div>
-    </nav>
-</header>
+<!--#include virtual="includes/header.html" -->
 
 <!-- ÜBER UNS -->
 <section class="banner" style="background-image:url('assets/empack_1.webp')">
@@ -100,11 +81,6 @@
 </section>
 
 <!-- FOOTER -->
-<footer>
-    <ul class="quicklinks">
-        <li><a href="datenschutz.html">Datenschutz</a></li>
-    </ul>
-    <p>&copy; 2024 Tirugo GmbH</p>
-</footer>
+<!--#include virtual="includes/footer.html" -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `includes/header.html` and `includes/footer.html`
- replace page specific header and footer HTML with includes

## Testing
- `npm test` *(fails: package.json missing)*
- `curl -I https://validator.w3.org/nu/` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842324d8bb08321aa5e8eed49f55d6c