### PR TITLE
Fix global header and footer injection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,16 +1,36 @@
 // Hamburger-Menü Toggle
-window.addEventListener('DOMContentLoaded', () => {
+async function loadLayout() {
+  if (!document.querySelector('header.site-header')) {
+    try {
+      const header = await fetch('includes/header.html');
+      const html = await header.text();
+      document.body.insertAdjacentHTML('afterbegin', html);
+    } catch (err) {
+      console.error('Header konnte nicht geladen werden', err);
+    }
+  }
+
+  if (!document.querySelector('footer')) {
+    try {
+      const footer = await fetch('includes/footer.html');
+      const html = await footer.text();
+      document.body.insertAdjacentHTML('beforeend', html);
+    } catch (err) {
+      console.error('Footer konnte nicht geladen werden', err);
+    }
+  }
+}
+
+function initInteractions() {
   const hamburger = document.querySelector('.hamburger');
   const navList = document.getElementById('nav-list');
-  hamburger.addEventListener('click', () => {
-    const expanded = hamburger.getAttribute('aria-expanded') === 'true';
-    hamburger.setAttribute('aria-expanded', !expanded);
-    if (expanded) {
-      navList.classList.remove('show');
-    } else {
-      navList.classList.add('show');
-    }
-  });
+  if (hamburger && navList) {
+    hamburger.addEventListener('click', () => {
+      const expanded = hamburger.getAttribute('aria-expanded') === 'true';
+      hamburger.setAttribute('aria-expanded', !expanded);
+      navList.classList.toggle('show', !expanded);
+    });
+  }
   // Smooth Scroll
   document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     if (anchor.getAttribute('href') !== '#') {
@@ -24,4 +44,9 @@ window.addEventListener('DOMContentLoaded', () => {
       });
     }
   });
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadLayout();
+  initInteractions();
 });

--- a/js/search.js
+++ b/js/search.js
@@ -1,7 +1,16 @@
 // Suchfunktion mit Seitennavigation
 document.addEventListener('DOMContentLoaded', () => {
-  const searchInput = document.getElementById('site-search');
-  const suggestions = document.getElementById('search-suggestions');
+  function waitForInput(callback) {
+    const input = document.getElementById('site-search');
+    const list = document.getElementById('search-suggestions');
+    if (input && list) {
+      callback(input, list);
+    } else {
+      setTimeout(() => waitForInput(callback), 50);
+    }
+  }
+
+  waitForInput((searchInput, suggestions) => {
 
   const pages = [
     { title: 'Startseite',       url: 'index.html',            keywords: 'flachform hubtische' },
@@ -91,4 +100,6 @@ document.addEventListener('DOMContentLoaded', () => {
       clearSuggestions();
     }
   });
+  });
 });
+


### PR DESCRIPTION
## Summary
- load header and footer HTML dynamically if missing
- wait for search bar elements before starting search functionality

## Testing
- `npx --yes lighthouse index.html --quiet --output=json --output-path=lh.json` *(fails: CHROME_PATH environment variable must be set)*
- `npx --yes html-validator-cli --file=index.html` *(fails: tunneling socket could not be established)*
- `npx --yes stylelint "**/*.css"` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68423689bb748321877a39d3c4806a13