### PR TITLE
Update header navigation and products

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -7,6 +7,7 @@
   nav ul { display: none; flex-direction: column; }
   nav .hamburger { display: block; }
   #nav-list.show { display: flex; }
+  .site-header .container { flex-wrap: wrap; }
   .search-container {
     order: 1;
     width: 100%;

--- a/css/styles.css
+++ b/css/styles.css
@@ -4,6 +4,16 @@ img { max-width: 100%; height: auto; }
 nav { display: flex; align-items: center; justify-content: space-between; padding: 1rem; }
 nav ul { list-style: none; display: flex; gap: 1rem; }
 nav .hamburger { display: none; }
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+}
+.nav-list { display: flex; gap: 30px; }
 .logo img {
   max-width: 150px;
   height: auto;

--- a/includes/header.html
+++ b/includes/header.html
@@ -11,6 +11,7 @@
         <li><a href="partner.html">Partner</a></li>
         <li><a href="ueber-uns.html">Über uns</a></li>
         <li><a href="online-beratung.html">Online Beratung</a></li>
+        <li><a href="service.html">Service</a></li>
         <li><a href="faq.html">FAQ</a></li>
         <li><a href="login.html">Login</a></li>
       </ul>

--- a/produkte.html
+++ b/produkte.html
@@ -47,12 +47,6 @@
         <p>Für extreme Anforderungen im Dauereinsatz.</p>
         <a href="fh.html">Mehr erfahren</a>
     </article>
-    <article id="petec-card">
-        <img src="assets/Petec_Logo.webp" alt="PETec Ergonomietisch" loading="lazy">
-        <h2>PETec Ergonomietische</h2>
-        <p>Elektrisch höhenverstellbare Arbeitstische mit modularen Erweiterungen.</p>
-        <a href="petec.html">Mehr erfahren</a>
-    </article>
 </section>
 
 


### PR DESCRIPTION
## Summary
- add *Service* link in the main navigation
- keep PETEC only on the partner page by removing the product card
- refine header layout styles so navigation fits on one line
- adapt responsive layout for small screens

## Testing
- `curl -I https://validator.w3.org` *(fails: 403 Forbidden)*
- `curl -F "uploadedfile=@css/styles.css" https://jigsaw.w3.org/css-validator/validator?output=json` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842393323dc8321bf9860b21cab79cc